### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/tests/HttpClientConfiguratorTest.php
+++ b/tests/HttpClientConfiguratorTest.php
@@ -5,8 +5,9 @@ namespace Happyr\ApiClient\Test;
 use Happyr\ApiClient\HttpClientConfigurator;
 use Http\Client\Common\Plugin\HeaderAppendPlugin;
 use Nyholm\NSA;
+use PHPUnit\Framework\TestCase;
 
-final class HttpClientConfiguratorTest extends \PHPUnit_Framework_TestCase
+final class HttpClientConfiguratorTest extends TestCase
 {
     public function testAppendPlugin()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).